### PR TITLE
Add USD currency requirement notice to QuickBooks documentation

### DIFF
--- a/finance/quickbooks-sync.mdx
+++ b/finance/quickbooks-sync.mdx
@@ -9,6 +9,10 @@ Flashquotes syncs payments, deposits, and refunds to QuickBooks Online. This pag
 QuickBooks sync requires an active Pro subscription and QuickBooks Online connection. Set up QuickBooks integration first in [Settings → Integrations](/settings/integrations/quickbooks).
 </Note>
 
+<Tip>
+QuickBooks syncing is only supported for accounts using USD currency in the United States.
+</Tip>
+
 ## How deposits work
 
 Flashquotes creates QuickBooks deposits differently depending on the payment method:

--- a/settings/integrations/quickbooks.mdx
+++ b/settings/integrations/quickbooks.mdx
@@ -34,6 +34,10 @@ The QuickBooks integration automatically syncs your invoices and payments betwee
 Requires a QuickBooks Online account and Pro tier Flashquotes subscription.
 </Note>
 
+<Tip>
+QuickBooks syncing is currently only available for accounts using USD currency in the United States. If your company uses a different currency, QuickBooks integration will not be available.
+</Tip>
+
 <Warning>
 Verify all mappings before initiating your first sync.
 </Warning>


### PR DESCRIPTION
## Summary
Added informational notices to the QuickBooks integration documentation clarifying that syncing is currently only supported for accounts using USD currency in the United States.

## Changes
- Added a tip notice to `finance/quickbooks-sync.mdx` explaining the USD currency requirement for QuickBooks syncing
- Added a similar tip notice to `settings/integrations/quickbooks.mdx` with additional context about currency limitations affecting integration availability
- Both notices are positioned prominently after the requirements section to ensure users are aware of this limitation before setup

## Details
These documentation updates inform users upfront about the geographic and currency constraints of the QuickBooks integration, helping prevent setup attempts that would not be supported and reducing support inquiries from users in unsupported regions or with non-USD currencies.

https://claude.ai/code/session_01CqPJUdDCccBxA2r1Z8cqYW