### PR TITLE
docs: update plan pricing and refresh plan subtexts

### DIFF
--- a/settings/plans.mdx
+++ b/settings/plans.mdx
@@ -11,21 +11,15 @@ Flashquotes plans are designed to match your stage of business growth:
 
 <CardGroup cols={3}>
   <Card title="Starter" icon="seedling">
-    **Level 1 caterers**
-    
-    Side hustlers and newcomers just getting started in the mobile event industry
+    For solo operators just getting started.
   </Card>
   
   <Card title="Plus" icon="bolt">
-    **Level 2 caterers**
-    
-    Full-time operations ready to go all-in on their catering business
+    CRM essentials for growth.
   </Card>
   
   <Card title="Pro" icon="crown">
-    **Level 3, 4, 5 caterers**
-    
-    Growing teams scaling operations and building a real enterprise
+    Move faster with automations and integrations.
   </Card>
 </CardGroup>
 
@@ -41,12 +35,12 @@ All plans include a 14-day free trial for paid tiers.
 
 | Plan | Monthly | Annual | Savings |
 |------|---------|--------|---------|
-| **Starter** | Free | Free | – |
-| **Plus** | $49/mo | $39/mo | Save 20% |
-| **Pro** | $99/mo | $83/mo | Save 20% |
+| **Starter** | Free | Free<span style={{ display: "block", lineHeight: 1, marginTop: "2px", fontSize: "0.85em", visibility: "hidden" }} aria-hidden="true">Billed annually</span> | – |
+| **Plus** | $59/mo | $49/mo<span style={{ display: "block", lineHeight: 1, marginTop: "2px", fontSize: "0.85em", opacity: 0.6 }}>Billed annually</span> | 2 months free |
+| **Pro** | $119/mo | $99/mo<span style={{ display: "block", lineHeight: 1, marginTop: "2px", fontSize: "0.85em", opacity: 0.6 }}>Billed annually</span> | 2 months free |
 
 <Tip>
-  Save 20% with annual billing. [Upgrade your plan →](https://app.flashquotes.com/settings/plans)
+  Get 2 months free with annual billing. [Upgrade your plan →](https://app.flashquotes.com/settings/plans)
 </Tip>
 
 ---
@@ -381,7 +375,7 @@ When you issue a full refund to a customer, Stripe processing fees and Flashquot
   </Accordion>
   
   <Accordion icon="percent" title="Do you offer discounts?">
-    Yes—annual billing saves 20% compared to monthly.
+    Yes—annual billing gets you 2 months free compared to monthly.
   </Accordion>
   
   <Accordion icon="star" title="How do service limits work?">


### PR DESCRIPTION
## Summary
- Bumped pricing: Plus $49→**$59/mo** ($39→**$49/mo** annual), Pro $99→**$119/mo** ($83→**$99/mo** annual)
- Replaced "Save 20%" framing with **"2 months free"** across the pricing table, Tip callout, and FAQ
- Added a smaller, faded **"Billed annually"** subline under the annual price in each row (with an invisible spacer on the Starter row so all rows share the same height)
- Rewrote the plan cards in "Which Plan Is Right for Me?" with concise persona-focused subtexts:
  - Starter — "For solo operators just getting started."
  - Plus — "CRM essentials for growth."
  - Pro — "Move faster with automations and integrations."

## Test plan
- [ ] Confirm the `/settings/plans` page renders the new prices, "2 months free" copy, and "Billed annually" subline correctly in both light and dark mode
- [ ] Verify all three table rows are visually the same height
- [ ] Verify the FAQ "Do you offer discounts?" answer reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated pricing page plan descriptions to better reflect Starter, Plus, and Pro tier capabilities.
  * Revised pricing table with updated monthly and annual rates.
  * Updated annual billing messaging to clearly communicate savings compared to monthly billing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Flashquotes/docs/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->