### PR TITLE
Add PostHog with standardized pricing event tracking

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,6 +11,10 @@
   "integrations": {
     "intercom": {
       "appId": "m2cqoqa0"
+    },
+    "posthog": {
+      "apiKey": "phc_vPoaIVndlcrDfAzd0ia1M8XtiXaewzoXUX6RvINtCRT",
+      "sessionRecording": true
     }
   },
   "api": {

--- a/pricing-events.js
+++ b/pricing-events.js
@@ -1,0 +1,179 @@
+(function () {
+  if (typeof window === "undefined") return;
+
+  const SURFACE = "docs";
+  const PRICE_VERSION = "2026-05-26";
+  const PLAN_NAMES = ["starter", "plus", "pro"];
+  const PLAN_PRICES = {
+    starter: { monthly: 0, yearly: 0 },
+    plus: { monthly: 59, yearly: 49 },
+    pro: { monthly: 119, yearly: 99 },
+  };
+
+  const CTA_PLAN_BY_PAGE = {
+    "/forms/conditional-logic": "plus",
+    "/forms/booking": "plus",
+    "/forms/lead-intake": "pro",
+    "/leads/instant-pricing": "pro",
+    "/api-reference/introduction": "pro",
+  };
+
+  const CTA_HREF_PATTERN = /app\.flashquotes\.com\/settings\/(plans|billing)/i;
+  const PRICING_PAGE_PATH = "/settings/plans";
+
+  let lastViewedPath = null;
+
+  function ph() {
+    return window.posthog;
+  }
+
+  function currentPath() {
+    return window.location.pathname.replace(/\/+$/, "") || "/";
+  }
+
+  function base() {
+    return {
+      surface: SURFACE,
+      page_path: currentPath(),
+      billing_period: "monthly",
+      visitor_plan: null,
+      price_version: PRICE_VERSION,
+    };
+  }
+
+  function fireViewed() {
+    const path = currentPath();
+    if (path !== PRICING_PAGE_PATH) return;
+    if (lastViewedPath === path) return;
+    lastViewedPath = path;
+    ph()?.capture("pricing_page_viewed", {
+      ...base(),
+      plans_displayed: ["starter", "plus", "pro"],
+    });
+  }
+
+  function planFromText(text) {
+    if (!text) return null;
+    const normalized = text.trim().toLowerCase();
+    for (const name of PLAN_NAMES) {
+      const re = new RegExp("(^|\\W)" + name + "(\\W|$)");
+      if (re.test(normalized)) return name;
+    }
+    return null;
+  }
+
+  function planFromAncestors(el) {
+    let node = el;
+    let depth = 0;
+    while (node && depth < 6) {
+      const text = node.textContent || "";
+      if (text.length < 200) {
+        const plan = planFromText(text);
+        if (plan) return plan;
+      }
+      node = node.parentElement;
+      depth++;
+    }
+    return null;
+  }
+
+  function ctaTypeFromText(text) {
+    const t = (text || "").toLowerCase();
+    if (t.includes("trial")) return "start_trial";
+    if (t.includes("contact")) return "contact_sales";
+    if (t.includes("sign up") || t.includes("signup")) return "signup";
+    return "upgrade";
+  }
+
+  function handleCtaClick(anchor) {
+    const href = anchor.getAttribute("href") || "";
+    if (!CTA_HREF_PATTERN.test(href)) return;
+    const pagePlan = CTA_PLAN_BY_PAGE[currentPath()];
+    const plan = pagePlan || planFromAncestors(anchor) || "plus";
+    const text = (anchor.textContent || "").trim();
+    ph()?.capture("pricing_cta_clicked", {
+      ...base(),
+      plan_name: plan,
+      plan_price: PLAN_PRICES[plan]?.monthly ?? null,
+      cta_text: text,
+      cta_type: ctaTypeFromText(text),
+    });
+  }
+
+  function handlePlanCardClick(target) {
+    if (currentPath() !== PRICING_PAGE_PATH) return;
+    // Mintlify Card renders title text inside the card; match by walking up
+    // looking for an ancestor whose own text is short and contains a plan name.
+    let node = target;
+    let depth = 0;
+    while (node && depth < 8) {
+      const text = (node.textContent || "").trim();
+      if (text.length > 0 && text.length < 160) {
+        const plan = planFromText(text);
+        if (plan) {
+          ph()?.capture("pricing_plan_highlighted", {
+            ...base(),
+            plan_name: plan,
+            plan_price: PLAN_PRICES[plan].monthly,
+            trigger: "click",
+          });
+          return;
+        }
+      }
+      node = node.parentElement;
+      depth++;
+    }
+  }
+
+  document.addEventListener("click", (e) => {
+    const target = e.target;
+    if (!(target instanceof Element)) return;
+    const anchor = target.closest("a[href]");
+    if (anchor) {
+      handleCtaClick(anchor);
+      return;
+    }
+    handlePlanCardClick(target);
+  });
+
+  const origPushState = history.pushState;
+  history.pushState = function () {
+    const result = origPushState.apply(this, arguments);
+    setTimeout(() => {
+      if (currentPath() !== lastViewedPath) lastViewedPath = null;
+      fireViewed();
+    }, 0);
+    return result;
+  };
+  const origReplaceState = history.replaceState;
+  history.replaceState = function () {
+    const result = origReplaceState.apply(this, arguments);
+    setTimeout(() => {
+      if (currentPath() !== lastViewedPath) lastViewedPath = null;
+      fireViewed();
+    }, 0);
+    return result;
+  };
+  window.addEventListener("popstate", () => {
+    setTimeout(() => {
+      if (currentPath() !== lastViewedPath) lastViewedPath = null;
+      fireViewed();
+    }, 0);
+  });
+
+  function init(attempts) {
+    if (!ph()) {
+      if (attempts > 50) return;
+      setTimeout(() => init(attempts + 1), 100);
+      return;
+    }
+    ph().register_for_session({ pricing_surface: SURFACE });
+    fireViewed();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => init(0));
+  } else {
+    init(0);
+  }
+})();


### PR DESCRIPTION
## Summary

- Enables Mintlify's built-in PostHog integration in `docs.json` (with session recording on)
- Adds `pricing-events.js` at the repo root — a single global script Mintlify auto-injects on every page — implementing the docs portion of the cross-surface `pricing_*` event spec
- Registers `pricing_surface: 'docs'` as a session super-property so any event in the session can be filtered by surface

## Events implemented

| Event | Where it fires |
|---|---|
| `pricing_page_viewed` | `/settings/plans` (initial load + SPA route changes, deduped per visit) |
| `pricing_cta_clicked` | Click on any link to `app.flashquotes.com/settings/plans` or `.../settings/billing`. Plan attribution uses a per-page map (feature-gated pages → Plus/Pro) with a text-based fallback. |
| `pricing_plan_highlighted` | Click inside a plan card on `/settings/plans` (`trigger: 'click'` only — hover/scroll skipped per spec) |

All events carry the spec's required base properties: `surface`, `page_path`, `billing_period`, `visitor_plan` (always `null` on docs), `price_version` (`2026-05-26`).

## Out of scope (per spec, not applicable to a static docs site)

- `pricing_billing_toggled` — no monthly/yearly toggle in the docs
- `pricing_feature_expanded` — Mintlify already auto-captures accordion toggles as `docs.*` events
- All `pricing_upsell_*` and `pricing_checkout_*` events — app-only

## Test plan

- [ ] Open `/settings/plans` on the Mintlify preview deploy and confirm in PostHog Live Events that `pricing_page_viewed` fires with all base properties plus `plans_displayed: ['starter','plus','pro']` and `pricing_surface: 'docs'` super-property
- [ ] Click "View Plans" / "Upgrade your plan" CTAs on `/settings/plans`, `/forms/booking`, and `/forms/lead-intake` — confirm `pricing_cta_clicked` fires with correct `plan_name` (`plus`, `plus`, `pro`) and `plan_price` (`59`, `59`, `119`)
- [ ] Click each of the three plan cards in the CardGroup on `/settings/plans` — confirm `pricing_plan_highlighted` fires with the right plan
- [ ] Navigate to `/settings/plans` via in-app link (SPA nav) and confirm `pricing_page_viewed` re-fires
- [ ] In PostHog → Settings → Session Replay → Authorized domains, add `docs.flashquotes.com` so session recordings capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for pricing page interactions including page views, call-to-action clicks, and plan selections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Flashquotes/docs/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->