### PR TITLE
docs: add Scale tier, backfill April/May changelog, and document new features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# Flashquotes Docs — Authoring Notes
+
+## MDX character escaping
+
+These docs render as MDX (Mintlify). A few characters need escaping inside prose and examples:
+
+| Character | When to escape | How |
+|-----------|----------------|-----|
+| `$` | In examples and prose, especially when followed by a number or `{` (e.g. `$5`, `${var}`) | `\$` |
+| `{` and `}` | Anywhere in prose that isn't an intentional JSX expression | `\{` and `\}` |
+| `<` and `>` | When the surrounding text isn't a JSX/HTML tag | `&lt;` and `&gt;` |
+| `*`, `_`, `` ` `` | When you want a literal, not Markdown emphasis or code | Backslash-escape (`\*`, `\_`, `` \` ``) |
+| `|` inside table cells | When the literal pipe is part of the cell content | `\|` |
+
+### Why `$` matters
+
+MDX runs through a JS-aware compiler. `${anything}` is treated as a template-string-like expression in some contexts and can break the build. Even when it doesn't break, unescaped `$` in price examples can render inconsistently across versions of the toolchain. **Always escape `$` in price examples** — `\$59/mo`, `\$1,125`, `(\$300)`.
+
+### Examples
+
+```mdx
+✅  **Example**: \$75/hour per bartender — a 4-hour service bills \$300 per bartender.
+❌  **Example**: $75/hour per bartender — a 4-hour service bills $300 per bartender.
+```
+
+### Exceptions
+
+Existing markdown tables in `settings/plans.mdx` use unescaped `$` (e.g. `$59/mo`) and render correctly. Match the surrounding pattern when editing inside an existing table; for **new prose and examples elsewhere**, escape.
+
+## Plan tier badges
+
+Badges live in `snippets/badge.mdx` and are imported per page:
+
+```mdx
+import { PlusBadge, ProBadge, ScaleBadge } from "/snippets/badge.mdx";
+```
+
+- `<PlusBadge />` — blue, marks Plus-tier features
+- `<ProBadge />` — green, marks Pro-tier features
+- `<ScaleBadge />` — orange, marks Scale-tier features (also used inline next to "Scale access required" callouts)
+
+Place the badge directly after the H2 title (e.g. `## Dynamic Pricing <ScaleBadge />`) for tier sections, or inline next to the feature reference in prose.
+
+## Changelog entries
+
+`changelog/overview.mdx` is ordered newest-first. Each entry is wrapped in `<Update label="Month DD, YYYY">…</Update>` with a single `##` title (optionally followed by a badge), a brief lead-in sentence, optional bullets, and a closing docs link. Keep entries tight — one feature per entry, scannable in seconds.

--- a/api-reference/introduction.mdx
+++ b/api-reference/introduction.mdx
@@ -3,12 +3,14 @@ title: "Introduction"
 description: "Welcome to the Flashquotes API documentation"
 ---
 
-## Welcome to the Flashquotes API
+import { ScaleBadge } from "/snippets/badge.mdx";
+
+## Welcome to the Flashquotes API <ScaleBadge />
 
 The Flashquotes API enables you to programmatically access and manage your events, bookings, forms, invoices, and tasks. Our REST API provides endpoints for retrieving event data, creating tasks, managing form responses, and accessing invoice information.
 
 <Tip>
-	API access is limited to Flashquotes Pro plan customers. You can easily
+	**Scale access required.** API access is limited to Flashquotes Scale plan customers. You can easily
 	upgrade in [Plan Settings](https://app.flashquotes.com/settings/plans).
 </Tip>
 
@@ -22,7 +24,7 @@ All API endpoints require authentication using an API key. You must include your
 
 <Note>
 	Keep your API key secure and never share it publicly. If you're subscribed to
-	the Pro plan, access your API key in the [Integrations
+	the Scale plan, access your API key in the [Integrations
 	Settings](https://app.flashquotes.com/settings/integrations).
 </Note>
 

--- a/calendar.mdx
+++ b/calendar.mdx
@@ -75,6 +75,25 @@ Click any calendar item to see its details.
 
 In **Day** or **Week** view, a timezone button appears in the calendar header. Click it to switch the displayed timezone.
 
+## Show service time vs. shift time
+
+Events render with their **shift time** by default — the full window your crew is on the clock, including setup and teardown. Toggle to **service time** to show only the customer-facing window.
+
+- **Shift time** — ideal for crew scheduling and resource planning
+- **Service time** — ideal for spotting customer conflicts and reading the calendar at a glance
+
+Use the **service time vs. shift time** toggle in the calendar header to switch.
+
+## Multi-day events
+
+Events that span more than one day render across each day they touch, so you can see the full footprint of a setup → event → teardown weekend without clicking into the event.
+
+## Resource availability
+
+Resources marked as busy on an event show on the calendar in their assigned event's time block. Use the **Resources** filter in the sidebar to focus on a single resource and spot conflicts before scheduling new work.
+
+[Learn more about resources →](/resources)
+
 ## Connect Google Calendar
 
 To sync your calendar with Google Calendar, upgrade to Flashquotes Plus. The upsell option appears at the bottom of the left sidebar.

--- a/calendar.mdx
+++ b/calendar.mdx
@@ -90,7 +90,7 @@ Events that span more than one day render across each day they touch, so you can
 
 ## Resource availability
 
-Resources marked as busy on an event show on the calendar in their assigned event's time block. Use the **Resources** filter in the sidebar to focus on a single resource and spot conflicts before scheduling new work.
+Resource availability is displayed on each day to give you a snapshot view of which days have high resource availability and which days are nearly booked out.
 
 [Learn more about resources →](/resources)
 

--- a/changelog/overview.mdx
+++ b/changelog/overview.mdx
@@ -15,9 +15,9 @@ This changelog documents product updates and new features in Flashquotes. These 
 
 Add a service to a quote and the travel fee calculates automatically — no second step, no manual math.
 
-- Travel fees recalculate when services or addresses change
-- Drive-time directions are cached so the quote editor stays fast
-- Works alongside [service-level travel fees](/services/travel-fees)
+- Auto-calculate travel fees when adding a new service line item to a quote
+- Override or remove the calculated fee on any line item
+- Configure per-service calculation with [service-level travel fees](/services/travel-fees)
 
 [Learn about travel fees →](/services/travel-fees)
 
@@ -45,7 +45,7 @@ Use [quote shortcodes](/workflows/shortcodes/overview) inside Service and Add-on
 
 - Personalize each line with guest count, event date, customer name, and more
 - Edit descriptions inline with a rich text editor
-- Shortcodes resolve when the quote is delivered
+- Shortcodes resolve when the quote is created
 
 [Learn about shortcodes →](/workflows/shortcodes/overview)
 
@@ -79,7 +79,7 @@ In the form editor, hover the button to highlight it, click to edit, then press 
 
 Charge differently for the same service depending on the event type — wedding pricing, corporate pricing, festival pricing, set once per service.
 
-- Per (service × event type) price modifier
+- Set a price modifier for any event type
 - Applies everywhere prices are calculated, including instant quoting
 - Pairs with the new [Event Type form question](/forms/lead-intake)
 
@@ -93,7 +93,7 @@ Charge differently for the same service depending on the event type — wedding 
 
 Ask customers what kind of event they're hosting, then surface that answer where it matters.
 
-- New **Event Type** lead intake form question — configure your own options
+- New **Event Type** lead intake form question — configure and sort your own options
 - Event type displays on the quote, the event details page, and booked events
 - Use it for filtering, reporting, and event-type pricing
 
@@ -109,7 +109,6 @@ Offer volume discounts on services and add-ons by setting per-guest pricing tier
 
 - **Service tiers** — drop the per-guest rate as guest counts climb, with an optional minimum hourly guests floor
 - **Add-on tiers** — the same volume-discount logic applies to add-ons
-- Prices recalculate automatically as guest counts change
 
 [Learn about service pricing →](/services/pricing) and [add-ons →](/services/add-ons)
 
@@ -119,11 +118,10 @@ Offer volume discounts on services and add-ons by setting per-guest pricing tier
 
 ## Surge Pricing and Days-Out Modifier <ScaleBadge />
 
-Charge more for high-demand dates and last-minute bookings — automatically.
+Charge more when resource availability is low or when bookings come in late — automatically.
 
-- **Surge pricing** for peak dates (Saturdays in June, holiday weekends, etc.)
-- **Days-out modifier** to upcharge bookings made with short lead time
-- Modifiers stack and apply across all services on the quote
+- **Surge pricing** — percentage uplift triggered when [resources linked to a service](/resources#service-specific-resources) are scarce on the event date (service-aware, no flat-fee option)
+- **Days-out modifier** — modify pricing based on event lead time (upcharge rush jobs, premium-price far-out reservations, or both)
 
 [See Scale plan features →](/settings/plans)
 
@@ -133,10 +131,10 @@ Charge more for high-demand dates and last-minute bookings — automatically.
 
 ## Per-Staff-Hour Travel Billing <PlusBadge />
 
-Charge for drive time per staff member instead of per vehicle.
+Bill drive time per staff member in addition to your per-mile, per-resource travel fee.
 
-- Travel costs scale with crew size, not trips
-- Pairs with [service-level travel fees](/services/travel-fees)
+- Travel labor scales with crew size — the per-mile, per-resource charge still covers the vehicles
+- Added on top of the existing travel fee (not subject to the mileage minimum)
 
 [Learn about travel fees →](/services/travel-fees)
 
@@ -146,10 +144,10 @@ Charge for drive time per staff member instead of per vehicle.
 
 ## Per-Shift-Hour Labor Pricing
 
-Bill labor by the on-site shift hour, excluding travel time.
+Choose how hourly labor is counted on each service — by **shift hours** (full on-site time, including setup and teardown) or **service hours** (the customer-facing window only).
 
-- Hourly labor charges scoped to the shift, not the full trip
-- Use alongside [per-staff-hour travel billing](/services/travel-fees) to itemize travel separately
+- Both modes exclude travel — bill drive time separately via [travel fees](/services/travel-fees)
+- Pairs naturally with [per-staff-hour travel billing](/services/travel-fees) to itemize travel as its own line
 
 [Learn about service pricing →](/services/pricing)
 

--- a/changelog/overview.mdx
+++ b/changelog/overview.mdx
@@ -3,11 +3,53 @@ title: "Product Updates"
 description: "New features and improvements to Flashquotes are released **every week**."
 ---
 
-import { PlusBadge, ProBadge } from "/snippets/badge.mdx";
+import { PlusBadge, ProBadge, ScaleBadge } from "/snippets/badge.mdx";
 
 <Note>
 This changelog documents product updates and new features in Flashquotes. These updates are rolled out directly to the live application - no separate changelog feature exists within the app itself.
 </Note>
+
+<Update label="May 21, 2026">
+
+## Auto-Calculate Travel Fee When Adding Services <PlusBadge />
+
+Add a service to a quote and the travel fee calculates automatically — no second step, no manual math.
+
+- Travel fees recalculate when services or addresses change
+- Drive-time directions are cached so the quote editor stays fast
+- Works alongside [service-level travel fees](/services/travel-fees)
+
+[Learn about travel fees →](/services/travel-fees)
+
+</Update>
+
+<Update label="May 19, 2026">
+
+## Resource Availability and Calendar Improvements
+
+See exactly when your resources are free, and view the calendar the way you actually work.
+
+- **Resource availability** in the quote editor and on the calendar — spot conflicts before they happen
+- **Service time vs. shift time** toggle on the calendar to plan around setup and teardown
+- **Multi-day events** render cleanly across both days
+
+[Learn more about resources →](/resources) and [calendar →](/calendar)
+
+</Update>
+
+<Update label="May 18, 2026">
+
+## Shortcodes in Line Item Descriptions
+
+Use [quote shortcodes](/workflows/shortcodes/overview) inside Service and Add-on line item descriptions on your quotes.
+
+- Personalize each line with guest count, event date, customer name, and more
+- Edit descriptions inline with a rich text editor
+- Shortcodes resolve when the quote is delivered
+
+[Learn about shortcodes →](/workflows/shortcodes/overview)
+
+</Update>
 
 <Update label="May 14, 2026">
 
@@ -28,6 +70,88 @@ You can now edit the CTA button copy on your lead intake form directly in the fo
 In the form editor, hover the button to highlight it, click to edit, then press **Enter** or click outside to save. Leave it blank to restore the default. Labels are capped at 100 characters.
 
 [Learn how to edit button labels →](/forms/lead-intake)
+
+</Update>
+
+<Update label="May 12, 2026">
+
+## Pricing by Event Type <ScaleBadge />
+
+Charge differently for the same service depending on the event type — wedding pricing, corporate pricing, festival pricing, set once per service.
+
+- Per (service × event type) price modifier
+- Applies everywhere prices are calculated, including instant quoting
+- Pairs with the new [Event Type form question](/forms/lead-intake)
+
+[Learn about pricing →](/services/pricing)
+
+</Update>
+
+<Update label="May 8, 2026">
+
+## Event Type on Quotes and Booked Events
+
+Ask customers what kind of event they're hosting, then surface that answer where it matters.
+
+- New **Event Type** lead intake form question — configure your own options
+- Event type displays on the quote, the event details page, and booked events
+- Use it for filtering, reporting, and event-type pricing
+
+[Learn about lead intake forms →](/forms/lead-intake)
+
+</Update>
+
+<Update label="May 4, 2026">
+
+## Tiered Pricing for Volume Discounts
+
+Offer volume discounts on services and add-ons by setting per-guest pricing tiers.
+
+- **Service tiers** — drop the per-guest rate as guest counts climb, with an optional minimum hourly guests floor
+- **Add-on tiers** — the same volume-discount logic applies to add-ons
+- Prices recalculate automatically as guest counts change
+
+[Learn about service pricing →](/services/pricing) and [add-ons →](/services/add-ons)
+
+</Update>
+
+<Update label="May 1, 2026">
+
+## Surge Pricing and Days-Out Modifier <ScaleBadge />
+
+Charge more for high-demand dates and last-minute bookings — automatically.
+
+- **Surge pricing** for peak dates (Saturdays in June, holiday weekends, etc.)
+- **Days-out modifier** to upcharge bookings made with short lead time
+- Modifiers stack and apply across all services on the quote
+
+[See Scale plan features →](/settings/plans)
+
+</Update>
+
+<Update label="April 30, 2026">
+
+## Per-Staff-Hour Travel Billing <PlusBadge />
+
+Charge for drive time per staff member instead of per vehicle.
+
+- Travel costs scale with crew size, not trips
+- Pairs with [service-level travel fees](/services/travel-fees)
+
+[Learn about travel fees →](/services/travel-fees)
+
+</Update>
+
+<Update label="April 30, 2026">
+
+## Per-Shift-Hour Labor Pricing
+
+Bill labor by the on-site shift hour, excluding travel time.
+
+- Hourly labor charges scoped to the shift, not the full trip
+- Use alongside [per-staff-hour travel billing](/services/travel-fees) to itemize travel separately
+
+[Learn about service pricing →](/services/pricing)
 
 </Update>
 

--- a/forms/lead-intake.mdx
+++ b/forms/lead-intake.mdx
@@ -20,6 +20,7 @@ The form editor displays all questions in the left panel, organized by page. Cli
     - **Lead Source** - Track how leads found you (pre-populated options)
     - **Add-ons** - Let leads select from your add-ons list
     - **Services** - Let leads choose from your services
+    - **Event Type** - Let leads pick the type of event (wedding, corporate, festival, etc.) — configurable options that surface on the quote and event details, and that can drive [event-type pricing](/services/pricing#dynamic-pricing) on the Scale plan
 
     **Custom Questions** collect any information you need:
     - **Text** - Short answer input

--- a/imports-exports/export-leads.mdx
+++ b/imports-exports/export-leads.mdx
@@ -76,7 +76,7 @@ Import data into Excel, Google Sheets, or BI tools to:
   Exports are limited to 1,000 leads per export to ensure optimal performance. For larger datasets, consider:
   - Filtering by date range before exporting
   - Exporting in batches
-  - Using the API for programmatic access (Enterprise plans)
+  - Using the API for programmatic access (Scale plan)
 </Note>
 
 ## File Format

--- a/pricing-events.js
+++ b/pricing-events.js
@@ -2,12 +2,13 @@
   if (typeof window === "undefined") return;
 
   const SURFACE = "docs";
-  const PRICE_VERSION = "2026-05-26";
-  const PLAN_NAMES = ["starter", "plus", "pro"];
+  const PRICE_VERSION = "2026-05-27";
+  const PLAN_NAMES = ["starter", "plus", "pro", "scale"];
   const PLAN_PRICES = {
     starter: { monthly: 0, yearly: 0 },
     plus: { monthly: 59, yearly: 49 },
     pro: { monthly: 119, yearly: 99 },
+    scale: { monthly: 249, yearly: 199 },
   };
 
   const CTA_PLAN_BY_PAGE = {
@@ -15,7 +16,7 @@
     "/forms/booking": "plus",
     "/forms/lead-intake": "pro",
     "/leads/instant-pricing": "pro",
-    "/api-reference/introduction": "pro",
+    "/api-reference/introduction": "scale",
   };
 
   const CTA_HREF_PATTERN = /app\.flashquotes\.com\/settings\/(plans|billing)/i;
@@ -48,7 +49,7 @@
     lastViewedPath = path;
     ph()?.capture("pricing_page_viewed", {
       ...base(),
-      plans_displayed: ["starter", "plus", "pro"],
+      plans_displayed: ["starter", "plus", "pro", "scale"],
     });
   }
 

--- a/resources.mdx
+++ b/resources.mdx
@@ -112,6 +112,14 @@ Resources can be assigned to events from the event detail page. When selecting r
 Assign resources to every event to keep your availability accurate and avoid overbooking.
 </Tip>
 
+## Resource Availability in the Quote Editor
+
+When you're building or editing a quote, the quote editor shows resource availability for the event date so you can spot conflicts before sending the quote.
+
+- See which resources are free vs. already committed on the event date
+- Catch double-bookings before they reach the customer
+- Resources also show on the [calendar](/calendar#resource-availability) — use the Resources filter to focus on a single asset
+
 ## Utilization Reporting
 
 Monitor your core service asset utilization on the [Reports](/reports#service-asset-utilization) page:

--- a/resources.mdx
+++ b/resources.mdx
@@ -116,7 +116,7 @@ Assign resources to every event to keep your availability accurate and avoid ove
 
 When you're building or editing a quote, the quote editor shows resource availability for the event date so you can spot conflicts before sending the quote.
 
-- See which resources are free vs. already committed on the event date
+- See how many resources are free on the event date
 - Catch double-bookings before they reach the customer
 - Resources also show on the [calendar](/calendar#resource-availability) — use the Resources filter to focus on a single asset
 

--- a/services/add-ons.mdx
+++ b/services/add-ons.mdx
@@ -59,6 +59,7 @@ Add-ons are extras and upsells that customers can add to their bookings. Navigat
     - **Per unit per hour**: Combined unit and hourly pricing
     - **Per unit per guest**: Price per unit scaled by guest count (and number of days); quantity is applied at line level (e.g. per-guest cocktail pricing with multiple options)
     - **Per guest per hour**: Price based on guest count multiplied by service duration in hours (and number of days); ideal for consumption-based add-ons that scale with both attendance and time
+    - **Tiered per guest**: Offer volume discounts on **Per guest** add-ons by setting rate bands (e.g. $5/guest for 1–49, $4/guest for 50–99, $3/guest for 100+). Customers see the right rate automatically as guest counts change.
 
     ### Minimum Price (Optional)
     For variable-rate add-ons (**Per guest**, **Per hour**, **Per resource**, **Per unit per hour**, **Per unit per guest**), you can set an optional minimum price. If the calculated price is below this amount, the minimum is used. Leave blank for no minimum. Flat rate and Per unit do not use minimum price.

--- a/services/add-ons.mdx
+++ b/services/add-ons.mdx
@@ -27,6 +27,7 @@ Add-ons are extras and upsells that customers can add to their bookings. Navigat
     Set up new add-ons with:
     - Display name
     - Description
+    - **Line Item Description** — how it appears on the quote and invoice. Supports rich text and [shortcodes](/workflows/shortcodes/overview) (e.g. `{{quote.guest_count}}`, `{{lead.first_name}}`) that resolve when the quote is created.
     - Pricing structure
     - Quantity limits (for Per unit, Per unit per hour, and Per unit per guest)
     - Minimum price (optional, for variable-rate add-ons)
@@ -59,7 +60,7 @@ Add-ons are extras and upsells that customers can add to their bookings. Navigat
     - **Per unit per hour**: Combined unit and hourly pricing
     - **Per unit per guest**: Price per unit scaled by guest count (and number of days); quantity is applied at line level (e.g. per-guest cocktail pricing with multiple options)
     - **Per guest per hour**: Price based on guest count multiplied by service duration in hours (and number of days); ideal for consumption-based add-ons that scale with both attendance and time
-    - **Tiered per guest**: Offer volume discounts on **Per guest** add-ons by setting rate bands (e.g. $5/guest for 1–49, $4/guest for 50–99, $3/guest for 100+). Customers see the right rate automatically as guest counts change.
+    - **Tiered per guest**: Offer volume discounts on **Per guest** add-ons by setting rate bands (e.g. \$5/guest for 1–49, \$4/guest for 50–99, \$3/guest for 100+). The applicable tier is chosen based on the guest count on the quote.
 
     ### Minimum Price (Optional)
     For variable-rate add-ons (**Per guest**, **Per hour**, **Per resource**, **Per unit per hour**, **Per unit per guest**), you can set an optional minimum price. If the calculated price is below this amount, the minimum is used. Leave blank for no minimum. Flat rate and Per unit do not use minimum price.
@@ -94,9 +95,9 @@ Add-ons are extras and upsells that customers can add to their bookings. Navigat
 
 <AccordionGroup>
   <Accordion icon="calculator" title="How Pricing Works">
-    **Per unit per guest**: Unit price × guests × days, then × quantity (e.g. $1 per guest per cocktail × 100 guests × 1 day = $100 per unit; quantity 3 = $300 total).
+    **Per unit per guest**: Unit price × guests × days, then × quantity (e.g. \$1 per guest per cocktail × 100 guests × 1 day = \$100 per unit; quantity 3 = \$300 total).
 
-    **Per guest per hour**: Unit price × guests × days × hours (e.g. $2/guest/hr × 50 guests × 1 day × 4 hours = $400).
+    **Per guest per hour**: Unit price × guests × days × hours (e.g. \$2/guest/hr × 50 guests × 1 day × 4 hours = \$400).
 
     **Minimum price**: If you set a minimum price, the line total will never be less than that amount for variable-rate add-ons.
 

--- a/services/core-services.mdx
+++ b/services/core-services.mdx
@@ -16,7 +16,7 @@ Navigate to **Services** in the main menu and click **New Service**.
 **Service fields:**
 - **Service Name**: What customers see on quotes (e.g., "Mobile Bar Service")
 - **Description**: Brief explanation for customers
-- **Line Item Description**: How it appears on invoices
+- **Line Item Description**: How it appears on invoices. Supports rich text formatting and [shortcodes](/workflows/shortcodes/overview) like `{{quote.guest_count}}` or `{{lead.first_name}}` — shortcodes resolve when the quote is created.
 - **Base Price**: Starting price for the service
 - **Minimum Price**: Lowest acceptable price
 - **Pricing Options**: Configure hourly rates and per-guest pricing
@@ -52,7 +52,7 @@ Navigate to **Services** in the main menu and click **New Service**.
     Make your service appealing:
     - **Service Image**: Upload a high-quality photo
     - **Description**: Clear, benefit-focused text
-    - **Line Item Description**: Professional invoice wording
+    - **Line Item Description**: Professional invoice wording — supports rich text and [shortcodes](/workflows/shortcodes/overview) (e.g. `{{quote.guest_count}}`) that resolve when the quote is created
 
     <Note>
       Good descriptions and images significantly improve conversion rates.

--- a/services/pricing.mdx
+++ b/services/pricing.mdx
@@ -24,20 +24,20 @@ Each service can use any combination of these pricing elements:
     - Use for setup fees, minimum charges, or equipment costs
     - Can be the entire price for simple flat-rate services
 
-    **Example**: $500 base for photo booth rental
+    **Example**: \$500 base for photo booth rental
   </Accordion>
 
   <Accordion icon="clock" title="Hourly Rate per Staff">
     Labor-based pricing:
     - Charged per hour, per staff member
-    - Choose how hours are counted: **shift hours** (on-site time only) or **full hours** (including travel time)
+    - Choose how hours are counted: **shift hours** (full crew shift — packing, unloading, on-site setup, service, and teardown) or **service hours** (the customer-facing service window only)
+    - Both modes exclude travel — bill drive time separately via [travel fees](/services/travel-fees)
     - Automatically multiplies by hours and staff count
-    - Perfect for services requiring skilled labor
 
-    **Example**: $75/hour per bartender, shift-hours mode — a 4-hour event = $300 per bartender, regardless of drive time
+    **Example**: \$75/hour per bartender. A 4-hour service with 1 hour packing/unloading and 30 min setup + 30 min teardown bills **6 shift hours** (\$450) or **4 service hours** (\$300) per bartender.
 
     <Tip>
-      Use **shift hours** when you bill travel separately via [travel fees](/services/travel-fees). Use **full hours** when labor and travel are billed together.
+      Use **shift hours** to charge for your crew's full on-the-clock time. Use **service hours** when you only want to bill the customer-facing portion of the event.
     </Tip>
   </Accordion>
 
@@ -47,27 +47,30 @@ Each service can use any combination of these pricing elements:
     - **Per guest**: Flat rate multiplied by guest count. Great for per-person food, favors, or fixed per-head costs.
     - **Per guest per hour**: Rate multiplied by guest count and event duration. Ideal when consumption or service scales with both attendance and time.
 
-    **Example (Per guest)**: $15 per guest for appetizer service — 50 guests = $750
-    **Example (Per guest per hour)**: $3/guest/hr for bar service — 50 guests × 4 hours = $600
+    **Example (Per guest)**: \$15 per guest for appetizer service — 50 guests = \$750
+
+    **Example (Per guest per hour)**: \$3/guest/hr for bar service — 50 guests × 4 hours = \$600
   </Accordion>
 
   <Accordion icon="layer-group" title="Tiered Per-Guest Pricing">
     Offer volume discounts as guest counts grow. Replaces a flat per-guest rate with rate bands.
 
-    - Set per-guest tiers (e.g. $20/guest for 1–49, $15/guest for 50–99, $12/guest for 100+)
-    - Works with both **Per guest** and **Per guest per hour** modes
+    - Set per-guest tiers (e.g. \$20/guest for 1–49, \$15/guest for 50–99, \$12/guest for 100+)
+    - Only works with the **Per guest** mode (not Per guest per hour)
     - Optional **minimum hourly guests** floor — bill against a minimum guest count for short, low-attendance events
 
-    **Example**: $20/guest under 50, $15/guest at 50+ — a 75-guest event bills $15 × 75 = $1,125
+    **Example**: \$20/guest under 50, \$15/guest at 50+ — a 75-guest event bills \$15 × 75 = \$1,125
   </Accordion>
 
   <Accordion icon="boxes-stacked" title="Price per Resource">
-    Resource-based pricing:
-    - Charged for each resource (equipment, machine, station) needed
-    - Automatically multiplies by number of resources on the quote
-    - Perfect for equipment rentals and multi-unit setups
+    Resource-based pricing. Choose how the resource rate is applied:
 
-    **Example**: $50 per espresso machine
+    - **Per resource**: Flat rate multiplied by resource count. Great for setup, delivery, or unit-based equipment fees.
+    - **Per resource per hour**: Rate multiplied by resource count and event duration. Useful for equipment that bills by run-time (machines, generators, espresso bars).
+
+    **Example (Per resource)**: \$50 per espresso machine — 2 machines = \$100
+
+    **Example (Per resource per hour)**: \$25/machine/hr — 2 machines × 4 hours = \$200
   </Accordion>
 
   <Accordion icon="cubes" title="Per Unit">
@@ -85,7 +88,7 @@ Each service can use any combination of these pricing elements:
     - Overrides calculated price if it's too low
     - Ensures every booking meets your minimum requirements
 
-    **Example**: $800 minimum for any event
+    **Example**: \$800 minimum for any event
   </Accordion>
 </AccordionGroup>
 
@@ -95,7 +98,7 @@ Your service price is calculated as:
 
 ```
 Final Price = MAX(
-  Base Price + (Staff × Hours × Hourly Rate) + Guest Component + (Resources × Per Resource Rate) + (Units × Per Unit Rate),
+  Base Price + (Staff × Hours × Hourly Rate) + Guest Component + Resource Component + (Units × Per Unit Rate),
   Minimum Price
 )
 ```
@@ -104,6 +107,11 @@ The **Guest Component** depends on the guest pricing mode set on the service:
 
 - **Per guest**: `Guests × Per Guest Rate`
 - **Per guest per hour**: `Guests × Hours × Per Guest Rate`
+
+The **Resource Component** depends on the resource pricing mode:
+
+- **Per resource**: `Resources × Per Resource Rate`
+- **Per resource per hour**: `Resources × Hours × Per Resource Rate`
 
 This ensures you're always paid at least your minimum while allowing flexible pricing based on event specifics.
 
@@ -114,7 +122,7 @@ This ensures you're always paid at least your minimum while allowing flexible pr
 **Setup**: High base price, no hourly or per-guest charges
 
 **Example**:
-- DJ Service: $1,500 base price
+- DJ Service: \$1,500 base price
 - Covers up to 5 hours
 - Simple, predictable pricing
 
@@ -123,7 +131,7 @@ This ensures you're always paid at least your minimum while allowing flexible pr
 **Setup**: Low/no base price, strong hourly component
 
 **Example**:
-- Bartending: $100 base + $75/hour per bartender
+- Bartending: \$100 base + \$75/hour per bartender
 - Scales with event duration
 - Fair for both short and long events
 
@@ -132,7 +140,7 @@ This ensures you're always paid at least your minimum while allowing flexible pr
 **Setup**: Base price for minimums, per-guest for scaling
 
 **Example**:
-- Catering: $500 base + $25 per guest
+- Catering: \$500 base + \$25 per guest
 - Covers fixed costs + variable food costs
 - Profitable at any event size
 
@@ -141,8 +149,8 @@ This ensures you're always paid at least your minimum while allowing flexible pr
 **Setup**: Per-guest rate that also scales with event duration (use "Per guest per hour" mode on the service)
 
 **Example**:
-- Bar or beverage service: $4/guest/hr
-- 75 guests × 5 hours = $1,500 from the guest component alone
+- Bar or beverage service: \$4/guest/hr
+- 75 guests × 5 hours = \$1,500 from the guest component alone
 - Ideal when consumption or service intensity scales with both attendance and time
 
 ### Per-Resource Services
@@ -151,8 +159,8 @@ This ensures you're always paid at least your minimum while allowing flexible pr
 
 **Example**:
 - Photo Booth Rental:
-  - $200 base (delivery/setup)
-  - $150 per booth
+  - \$200 base (delivery/setup)
+  - \$150 per booth
   - Scales with equipment count
 
 ### Per-Unit Services
@@ -161,8 +169,8 @@ This ensures you're always paid at least your minimum while allowing flexible pr
 
 **Example**:
 - Balloon Twisting:
-  - $150 base (setup/travel)
-  - $3 per balloon, min 50, max 300
+  - \$150 base (setup/travel)
+  - \$3 per balloon, min 50, max 300
   - Ideal when consumption doesn't scale with attendance and you'd rather have the customer order a specific quantity
 
 ### Hybrid Pricing
@@ -171,11 +179,11 @@ This ensures you're always paid at least your minimum while allowing flexible pr
 
 **Example**:
 - Full Bar Service:
-  - $300 base (equipment/setup)
-  - $75/hour per bartender (labor)
-  - $12 per guest (supplies)
-  - $5 per signature cocktail kit (per unit, min 10)
-  - $1,000 minimum
+  - \$300 base (equipment/setup)
+  - \$75/hour per bartender (labor)
+  - \$12 per guest (supplies)
+  - \$5 per signature cocktail kit (per unit, min 10)
+  - \$1,000 minimum
 
 ## Setting Your Prices
 
@@ -223,41 +231,28 @@ Adjust prices automatically based on demand, lead time, and event type. Dynamic 
 
 <AccordionGroup>
   <Accordion icon="chart-line" title="Surge Pricing">
-    Charge more for high-demand dates:
-    - Set premium rates for specific dates or recurring patterns (Saturdays in June, holiday weekends)
-    - Apply as a percentage uplift or fixed amount
-    - Auto-applies on any quote for matching dates
+    Automatically charge more when **resource availability is low** for a service — high demand triggers a price uplift, no manual adjustment required.
+
+    - **Percentage modifier** added to the service price when availability dips
+    - **Service-aware** — references only the resources [linked to that service](/resources#service-specific-resources), so demand is measured per service rather than across all your resources
+    - Auto-applies on any quote for dates where the linked resources are scarce
   </Accordion>
 
   <Accordion icon="clock-rotate-left" title="Days-Out Modifier">
-    Upcharge last-minute bookings:
-    - Set tiers based on days between the booking and the event (e.g. +30% within 7 days, +15% within 30 days)
-    - Encourages earlier bookings and offsets the cost of rush jobs
+    Modify the service price based on **event lead time** — how far out the event is from the booking date. Use it to upcharge rush jobs, charge a premium for far-out reservations that lock up your calendar, or both.
+
+    - Set tiers by days between the booking and the event
+    - **Short lead time** — e.g. +30% within 7 days to cover the cost of rush jobs
+    - **Long lead time** — e.g. +10% beyond 12 months to price in the opportunity cost of holding the date
   </Accordion>
 
   <Accordion icon="tags" title="Pricing by Event Type">
     Charge differently for the same service depending on event type — wedding, corporate, festival, and more:
-    - Set per-(service × event type) price modifiers
+    - Set the price modifier for each event type on a service
     - Bump or discount specific event types
     - Captured from the [Event Type form question](/forms/lead-intake) on your lead intake form
   </Accordion>
 </AccordionGroup>
-
-## Add-On Pricing
-
-In addition to service pricing, you can create add-ons with their own pricing models:
-
-- **Flat rate**: Fixed price add-ons
-- **Per unit**: Quantity-based pricing
-- **Per guest**: Scales with attendance
-- **Per hour**: Time-based add-ons
-- **Per resource**: Resource-dependent pricing
-- **Per unit per hour**: Combined unit and hourly pricing
-- **Per unit per guest**: Quantity-based pricing scaled by guest count (and number of days)
-- **Per guest per hour**: Price based on guest count multiplied by service duration in hours
-- **Minimum price**: Optional floor for variable-rate add-ons (Per guest, Per hour, Per resource, Per unit per hour, Per unit per guest, Per guest per hour); if the calculated price is below the minimum, the minimum is used
-
-[Learn more about add-on pricing →](/services/add-ons)
 
 ## Service Charges
 
@@ -268,10 +263,10 @@ Navigate to **Settings → Service Charges** to configure these additional fees.
 ## Common Questions
 
 **Q: Can I have different prices for different event types?**
-A: Yes — use [Pricing by Event Type](#dynamic-pricing) <ScaleBadge /> to apply different rates for weddings, corporate events, festivals, and more, all within a single service. See [Structuring Your Services](/services/structuring-services) for best practices.
+A: Yes — use [Pricing by Event Type](#dynamic-pricing) to apply different rates for weddings, corporate events, festivals, and more, all within a single service. See [Structuring Your Services](/services/structuring-services) for best practices.
 
 **Q: How do I handle peak season pricing?**
-A: Use [Surge Pricing](#dynamic-pricing) <ScaleBadge /> to set premium rates on high-demand dates or recurring patterns. Modifiers apply automatically on matching quotes.
+A: Use [Surge Pricing](#dynamic-pricing) to set premium rates on high-demand dates. Modifiers apply automatically on matching quotes.
 
 **Q: What if my costs vary by location?**
 A: Use the minimum price to ensure you cover base costs, and configure travel fees as an add-on or manual adjustment.

--- a/services/pricing.mdx
+++ b/services/pricing.mdx
@@ -3,6 +3,8 @@ title: "Service Pricing"
 description: "Configure pricing for your services using flexible pricing components"
 ---
 
+import { PlusBadge, ScaleBadge } from "/snippets/badge.mdx";
+
 ## How Service Pricing Works
 
 In Flashquotes, pricing is configured directly on each service. You can combine multiple pricing components to create the perfect pricing structure for your business.
@@ -28,10 +30,15 @@ Each service can use any combination of these pricing elements:
   <Accordion icon="clock" title="Hourly Rate per Staff">
     Labor-based pricing:
     - Charged per hour, per staff member
+    - Choose how hours are counted: **shift hours** (on-site time only) or **full hours** (including travel time)
     - Automatically multiplies by hours and staff count
     - Perfect for services requiring skilled labor
 
-    **Example**: $75/hour per bartender
+    **Example**: $75/hour per bartender, shift-hours mode — a 4-hour event = $300 per bartender, regardless of drive time
+
+    <Tip>
+      Use **shift hours** when you bill travel separately via [travel fees](/services/travel-fees). Use **full hours** when labor and travel are billed together.
+    </Tip>
   </Accordion>
 
   <Accordion icon="users" title="Price per Guest">
@@ -42,6 +49,16 @@ Each service can use any combination of these pricing elements:
 
     **Example (Per guest)**: $15 per guest for appetizer service — 50 guests = $750
     **Example (Per guest per hour)**: $3/guest/hr for bar service — 50 guests × 4 hours = $600
+  </Accordion>
+
+  <Accordion icon="layer-group" title="Tiered Per-Guest Pricing">
+    Offer volume discounts as guest counts grow. Replaces a flat per-guest rate with rate bands.
+
+    - Set per-guest tiers (e.g. $20/guest for 1–49, $15/guest for 50–99, $12/guest for 100+)
+    - Works with both **Per guest** and **Per guest per hour** modes
+    - Optional **minimum hourly guests** floor — bill against a minimum guest count for short, low-attendance events
+
+    **Example**: $20/guest under 50, $15/guest at 50+ — a 75-guest event bills $15 × 75 = $1,125
   </Accordion>
 
   <Accordion icon="boxes-stacked" title="Price per Resource">
@@ -200,6 +217,32 @@ This ensures you're always paid at least your minimum while allowing flexible pr
   </Card>
 </CardGroup>
 
+## Dynamic Pricing <ScaleBadge />
+
+Adjust prices automatically based on demand, lead time, and event type. Dynamic modifiers stack on top of your base pricing.
+
+<AccordionGroup>
+  <Accordion icon="chart-line" title="Surge Pricing">
+    Charge more for high-demand dates:
+    - Set premium rates for specific dates or recurring patterns (Saturdays in June, holiday weekends)
+    - Apply as a percentage uplift or fixed amount
+    - Auto-applies on any quote for matching dates
+  </Accordion>
+
+  <Accordion icon="clock-rotate-left" title="Days-Out Modifier">
+    Upcharge last-minute bookings:
+    - Set tiers based on days between the booking and the event (e.g. +30% within 7 days, +15% within 30 days)
+    - Encourages earlier bookings and offsets the cost of rush jobs
+  </Accordion>
+
+  <Accordion icon="tags" title="Pricing by Event Type">
+    Charge differently for the same service depending on event type — wedding, corporate, festival, and more:
+    - Set per-(service × event type) price modifiers
+    - Bump or discount specific event types
+    - Captured from the [Event Type form question](/forms/lead-intake) on your lead intake form
+  </Accordion>
+</AccordionGroup>
+
 ## Add-On Pricing
 
 In addition to service pricing, you can create add-ons with their own pricing models:
@@ -225,10 +268,10 @@ Navigate to **Settings → Service Charges** to configure these additional fees.
 ## Common Questions
 
 **Q: Can I have different prices for different event types?**
-A: Use event type conditional pricing (Pro feature) to apply different rates for weddings, corporate events, etc.—all within a single service. See [Structuring Your Services](/services/structuring-services) for best practices.
+A: Yes — use [Pricing by Event Type](#dynamic-pricing) <ScaleBadge /> to apply different rates for weddings, corporate events, festivals, and more, all within a single service. See [Structuring Your Services](/services/structuring-services) for best practices.
 
 **Q: How do I handle peak season pricing?**
-A: Adjust quotes manually for peak season, or use conditional pricing rules when available.
+A: Use [Surge Pricing](#dynamic-pricing) <ScaleBadge /> to set premium rates on high-demand dates or recurring patterns. Modifiers apply automatically on matching quotes.
 
 **Q: What if my costs vary by location?**
 A: Use the minimum price to ensure you cover base costs, and configure travel fees as an add-on or manual adjustment.

--- a/services/travel-fees.mdx
+++ b/services/travel-fees.mdx
@@ -38,13 +38,18 @@ Distance around your business with no travel charge. Events beyond this radius a
 
 ### Per-Staff-Hour Travel Billing <PlusBadge />
 
-Charge for drive time per staff member rather than per vehicle. Useful when you pay your crew for travel hours and want to recover that cost on the quote.
+Bill drive time per staff member **in addition to** the per-mile, per-resource travel fee. Useful when you pay your crew for travel hours and want to recover that cost on the quote alongside vehicle costs.
 
 - Set an **hourly travel rate per staff member**
 - Drive time is calculated from your business location to the event address
 - Bills round-trip drive time × staff count per service
+- Added on top of the per-mile, per-resource fee — not a replacement for it
 
-**Example**: 1 hour each way × 3 staff × $25/hour = $150 travel labor on the quote
+<Note>
+  The **Minimum Travel Fee** only applies to the mileage portion of the travel fee. Per-staff-hour travel billing is always added in full on top — it is not subject to the minimum.
+</Note>
+
+**Example**: 2 hours round-trip × 3 staff × \$25/hour = \$150 travel labor on the quote
 
 ## How It's Calculated
 
@@ -81,7 +86,3 @@ Travel fees show as line items on each service. You can:
 ## Auto-Calculation in the Quote Editor <PlusBadge />
 
 When you add a service to a quote in the quote editor, the travel fee is calculated and added automatically — no extra step required.
-
-- Fees recalculate when you change services or the event address
-- Drive-time directions are cached so subsequent edits stay fast
-- Override or remove a calculated fee at any time on the line item

--- a/services/travel-fees.mdx
+++ b/services/travel-fees.mdx
@@ -30,10 +30,21 @@ Distance around your business with no travel charge. Events beyond this radius a
 
 - **Price Per Mile**: Rate per mile, applied to round-trip distance per day per core resource
 - **Minimum Travel Fee**: Floor amount per core resource per day — used when higher than the distance-based fee
+- **Per-Staff-Hour Travel**: Optionally bill drive time per staff member instead of (or alongside) per-mile pricing — travel costs scale with crew size
 
 <Tip>
   Each service can have different price per mile and minimum — useful if one service needs a larger vehicle or more equipment.
 </Tip>
+
+### Per-Staff-Hour Travel Billing <PlusBadge />
+
+Charge for drive time per staff member rather than per vehicle. Useful when you pay your crew for travel hours and want to recover that cost on the quote.
+
+- Set an **hourly travel rate per staff member**
+- Drive time is calculated from your business location to the event address
+- Bills round-trip drive time × staff count per service
+
+**Example**: 1 hour each way × 3 staff × $25/hour = $150 travel labor on the quote
 
 ## How It's Calculated
 
@@ -66,3 +77,11 @@ Travel fees show as line items on each service. You can:
 <Note>
   Travel fees are auto-calculated on quote requests from your lead intake form when a location and event address are provided. Each service gets its own fee based on its core resource count.
 </Note>
+
+## Auto-Calculation in the Quote Editor <PlusBadge />
+
+When you add a service to a quote in the quote editor, the travel fee is calculated and added automatically — no extra step required.
+
+- Fees recalculate when you change services or the event address
+- Drive-time directions are cached so subsequent edits stay fast
+- Override or remove a calculated fee at any time on the line item

--- a/settings/plans.mdx
+++ b/settings/plans.mdx
@@ -273,7 +273,7 @@ Everything in Pro, plus dynamic pricing tools and enterprise-grade API and suppo
 
 <AccordionGroup>
   <Accordion icon="chart-line" title="Dynamic Pricing">
-    Adjust pricing based on demand, timing, and event type:
+    Adjust pricing based on demand, timing, event type, and more:
     - **Surge pricing** for high-demand dates
     - **Upcharge last-minute bookings** when lead time is short
     - **Charge more (or less) for certain event types** to match how you actually price work

--- a/settings/plans.mdx
+++ b/settings/plans.mdx
@@ -271,6 +271,10 @@ Everything in Plus, plus enterprise-grade features for scaling your business.
 
 Everything in Pro, plus dynamic pricing tools and enterprise-grade API and support for high-volume operations.
 
+<Card title="Upgrade to Scale" icon="rocket" href="https://app.flashquotes.com/settings/plans">
+  Unlock dynamic pricing, full API access, and VIP priority support.
+</Card>
+
 <AccordionGroup>
   <Accordion icon="chart-line" title="Dynamic Pricing">
     Adjust pricing based on demand, timing, event type, and more:

--- a/settings/plans.mdx
+++ b/settings/plans.mdx
@@ -3,13 +3,13 @@ title: "Plans & Pricing"
 description: "Compare Flashquotes subscription plans and discover which features are included at each tier"
 ---
 
-import { PlusBadge, ProBadge } from "/snippets/badge.mdx";
+import { PlusBadge, ProBadge, ScaleBadge } from "/snippets/badge.mdx";
 
 ## Which Plan Is Right for Me?
 
 Flashquotes plans are designed to match your stage of business growth:
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Starter" icon="seedling">
     For solo operators just getting started.
   </Card>
@@ -20,6 +20,10 @@ Flashquotes plans are designed to match your stage of business growth:
   
   <Card title="Pro" icon="crown">
     Move faster with automations and integrations.
+  </Card>
+
+  <Card title="Scale" icon="rocket">
+    For organizations seeking advanced control & flexibility.
   </Card>
 </CardGroup>
 
@@ -38,6 +42,7 @@ All plans include a 14-day free trial for paid tiers.
 | **Starter** | Free | Free<span style={{ display: "block", lineHeight: 1, marginTop: "2px", fontSize: "0.85em", visibility: "hidden" }} aria-hidden="true">Billed annually</span> | – |
 | **Plus** | $59/mo | $49/mo<span style={{ display: "block", lineHeight: 1, marginTop: "2px", fontSize: "0.85em", opacity: 0.6 }}>Billed annually</span> | 2 months free |
 | **Pro** | $119/mo | $99/mo<span style={{ display: "block", lineHeight: 1, marginTop: "2px", fontSize: "0.85em", opacity: 0.6 }}>Billed annually</span> | 2 months free |
+| **Scale** | $249/mo | $199/mo<span style={{ display: "block", lineHeight: 1, marginTop: "2px", fontSize: "0.85em", opacity: 0.6 }}>Billed annually</span> | 2 months free |
 
 <Tip>
   Get 2 months free with annual billing. [Upgrade your plan →](https://app.flashquotes.com/settings/plans)
@@ -218,27 +223,11 @@ Everything in Plus, plus enterprise-grade features for scaling your business.
     [Set up Zapier →](/settings/integrations/zapier)
   </Accordion>
   
-  <Accordion icon="code" title="API Access">
-    Build custom integrations with our REST API:
-    - Generate and manage [API keys](/api-reference/introduction)
-    - Access event, task, invoice, and form data
-    - Create custom workflows and integrations
-    - Full programmatic control of your data
-    
-    [View API documentation →](/api-reference/introduction)
-  </Accordion>
-  
   <Accordion icon="sparkles" title="White Label Branding">
     Remove Flashquotes branding from client-facing pages:
     - Quote views without "Powered by Flashquotes"
     - Booking forms without attribution
     - Professional, branded client experience
-  </Accordion>
-  
-  <Accordion icon="headset" title="VIP Priority Support">
-    Get faster responses from our support team:
-    - Priority email support queue
-    - Dedicated assistance for complex setups
   </Accordion>
 
   <Accordion icon="chart-line" title="Google Analytics & Tag Manager">
@@ -278,47 +267,82 @@ Everything in Plus, plus enterprise-grade features for scaling your business.
 
 ---
 
+## Scale <ScaleBadge />
+
+Everything in Pro, plus dynamic pricing tools and enterprise-grade API and support for high-volume operations.
+
+<AccordionGroup>
+  <Accordion icon="chart-line" title="Dynamic Pricing">
+    Adjust pricing based on demand, timing, and event type:
+    - **Surge pricing** for high-demand dates
+    - **Upcharge last-minute bookings** when lead time is short
+    - **Charge more (or less) for certain event types** to match how you actually price work
+  </Accordion>
+
+  <Accordion icon="code" title="Full API Access">
+    Build custom integrations with our REST API:
+    - Generate and manage [API keys](/api-reference/introduction)
+    - Access event, task, invoice, and form data
+    - Create custom workflows and integrations
+    - Full programmatic control of your data
+
+    [View API documentation →](/api-reference/introduction)
+  </Accordion>
+
+  <Accordion icon="headset" title="VIP Priority Support">
+    Get faster responses from our support team:
+    - Priority email support queue
+    - Dedicated assistance for complex setups
+  </Accordion>
+</AccordionGroup>
+
+---
+
 ## Feature Comparison
 
-| Feature | Starter | Plus | Pro |
-|---------|:-------:|:----:|:---:|
-| **Services & Pricing** | | | |
-| [Services](/services/structuring-services) | 1 | 5 | Unlimited |
-| [Add-ons](/services/add-ons) | Unlimited | Unlimited | Unlimited |
-| **Lead Capture** | | | |
-| Lead intake forms | ✅ | ✅ | ✅ |
-| Booking forms | ✅ | ✅ | ✅ |
-| Conditional form logic | – | ✅ | ✅ |
-| **Quoting & Invoicing** | | | |
-| Quote creation & delivery | ✅ | ✅ | ✅ |
-| Quote templates | 1 | Up to 3 | Unlimited |
-| Instant quoting | – | – | ✅ |
-| Invoice generation | ✅ | ✅ | ✅ |
-| Stripe payments | ✅ | ✅ | ✅ |
-| Automated travel fee | – | ✅ | ✅ |
-| **Contracts** | | | |
-| Digital contracts | – | Up to 2 | Unlimited |
-| **Event Management** | | | |
-| Event management | ✅ | ✅ | ✅ |
-| Checklist templates | – | ✅ | ✅ |
-| Staff auto-invite to calendar | – | – | ✅ |
-| **CRM** | | | |
-| Lead owner assignment | – | ✅ | ✅ |
-| **Automation** | | | |
-| Basic workflow triggers | ✅ | ✅ | ✅ |
-| Advanced workflow triggers | – | ✅ | ✅ |
-| **Integrations** | | | |
-| Gmail integration | – | ✅ | ✅ |
-| Google Calendar sync | – | ✅ | ✅ |
-| Service-specific add-ons | – | ✅ | ✅ |
-| Service-specific resources | – | ✅ | ✅ |
-| QuickBooks integration | – | – | ✅ |
-| Google Analytics & GTM | – | – | ✅ |
-| Zapier integration | – | – | ✅ |
-| API access | – | – | ✅ |
-| **Support & Branding** | | | |
-| Remove branding | – | – | ✅ |
-| VIP support | – | – | ✅ |
+| Feature | Starter | Plus | Pro | Scale |
+|---------|:-------:|:----:|:---:|:-----:|
+| **Services & Pricing** | | | | |
+| [Services](/services/structuring-services) | 1 | 5 | Unlimited | Unlimited |
+| [Add-ons](/services/add-ons) | Unlimited | Unlimited | Unlimited | Unlimited |
+| Dynamic pricing | – | – | – | ✅ |
+| Surge pricing | – | – | – | ✅ |
+| Last-minute upcharges | – | – | – | ✅ |
+| Event-type pricing | – | – | – | ✅ |
+| **Lead Capture** | | | | |
+| Lead intake forms | ✅ | ✅ | ✅ | ✅ |
+| Booking forms | ✅ | ✅ | ✅ | ✅ |
+| Conditional form logic | – | ✅ | ✅ | ✅ |
+| **Quoting & Invoicing** | | | | |
+| Quote creation & delivery | ✅ | ✅ | ✅ | ✅ |
+| Quote templates | 1 | Up to 3 | Unlimited | Unlimited |
+| Instant quoting | – | – | ✅ | ✅ |
+| Invoice generation | ✅ | ✅ | ✅ | ✅ |
+| Stripe payments | ✅ | ✅ | ✅ | ✅ |
+| Automated travel fee | – | ✅ | ✅ | ✅ |
+| **Contracts** | | | | |
+| Digital contracts | – | Up to 2 | Unlimited | Unlimited |
+| **Event Management** | | | | |
+| Event management | ✅ | ✅ | ✅ | ✅ |
+| Checklist templates | – | ✅ | ✅ | ✅ |
+| Staff auto-invite to calendar | – | – | ✅ | ✅ |
+| **CRM** | | | | |
+| Lead owner assignment | – | ✅ | ✅ | ✅ |
+| **Automation** | | | | |
+| Basic workflow triggers | ✅ | ✅ | ✅ | ✅ |
+| Advanced workflow triggers | – | ✅ | ✅ | ✅ |
+| **Integrations** | | | | |
+| Gmail integration | – | ✅ | ✅ | ✅ |
+| Google Calendar sync | – | ✅ | ✅ | ✅ |
+| Service-specific add-ons | – | ✅ | ✅ | ✅ |
+| Service-specific resources | – | ✅ | ✅ | ✅ |
+| QuickBooks integration | – | – | ✅ | ✅ |
+| Google Analytics & GTM | – | – | ✅ | ✅ |
+| Zapier integration | – | – | ✅ | ✅ |
+| Full API access | – | – | – | ✅ |
+| **Support & Branding** | | | | |
+| Remove branding | – | – | ✅ | ✅ |
+| VIP support | – | – | – | ✅ |
 
 ---
 
@@ -367,7 +391,7 @@ When you issue a full refund to a customer, Stripe processing fees and Flashquot
   </Accordion>
   
   <Accordion icon="clock" title="How does the free trial work?">
-    Both Plus and Pro plans include a 14-day free trial. You'll have full access to all features during the trial. If you don't subscribe before the trial ends, you'll be moved to the Starter plan.
+    Plus, Pro, and Scale plans include a 14-day free trial. You'll have full access to all features during the trial. If you don't subscribe before the trial ends, you'll be moved to the Starter plan.
   </Accordion>
   
   <Accordion icon="users" title="Are there per-user fees?">
@@ -379,7 +403,7 @@ When you issue a full refund to a customer, Stripe processing fees and Flashquot
   </Accordion>
   
   <Accordion icon="star" title="How do service limits work?">
-    Each plan includes a set number of [services](/services/structuring-services): Starter includes 1, Plus includes 5, and Pro includes unlimited. A service is a distinct, bookable offering (like "Espresso Bar" or "Hot Chocolate Cart"). 
+    Each plan includes a set number of [services](/services/structuring-services): Starter includes 1, Plus includes 5, and Pro and Scale include unlimited. A service is a distinct, bookable offering (like "Espresso Bar" or "Hot Chocolate Cart"). 
     
     Most businesses need only 1-3 services—use [pricing rules](/services/pricing) for variations (duration, guest count) and [add-ons](/services/add-ons) for extras (custom cups, additional hours). All plans include unlimited add-ons.
   </Accordion>

--- a/snippets/badge.mdx
+++ b/snippets/badge.mdx
@@ -31,3 +31,20 @@ export const ProBadge = () => (
     Pro
   </span>
 );
+
+export const ScaleBadge = () => (
+  <span style={{
+    backgroundColor: '#F5F3FF',
+    color: '#7C3AED',
+    padding: '2px 8px',
+    borderRadius: '4px',
+    fontSize: '12px',
+    fontWeight: '600',
+    marginLeft: '6px',
+    display: 'inline-block',
+    verticalAlign: 'middle',
+    border: '1px solid #DDD6FE'
+  }}>
+    Scale
+  </span>
+);

--- a/snippets/badge.mdx
+++ b/snippets/badge.mdx
@@ -34,8 +34,8 @@ export const ProBadge = () => (
 
 export const ScaleBadge = () => (
   <span style={{
-    backgroundColor: '#F5F3FF',
-    color: '#7C3AED',
+    backgroundColor: '#FFF7ED',
+    color: '#EA580C',
     padding: '2px 8px',
     borderRadius: '4px',
     fontSize: '12px',
@@ -43,7 +43,7 @@ export const ScaleBadge = () => (
     marginLeft: '6px',
     display: 'inline-block',
     verticalAlign: 'middle',
-    border: '1px solid #DDD6FE'
+    border: '1px solid #FED7AA'
   }}>
     Scale
   </span>

--- a/workflows/shortcodes/overview.mdx
+++ b/workflows/shortcodes/overview.mdx
@@ -18,7 +18,7 @@ Short codes are formatted as `{{entity.attribute}}` and must be surrounded by `{
 Shortcodes resolve in:
 
 - **Workflow email templates** — Quote Sent, Quote Booked, First Event Start, Last Event End
-- **Quote line item descriptions** — Service and Add-on descriptions on a quote. Personalize each line with guest count, event date, customer name, and more using the same `{{entity.attribute}}` syntax. Shortcodes resolve when the quote is delivered.
+- **Quote line item descriptions** — Service and Add-on descriptions on a quote. Personalize each line with guest count, event date, customer name, and more using the same `{{entity.attribute}}` syntax. Shortcodes resolve when the quote is created.
 
 ## Available Shortcodes by Trigger
 

--- a/workflows/shortcodes/overview.mdx
+++ b/workflows/shortcodes/overview.mdx
@@ -3,7 +3,7 @@ title: "Overview"
 description: "Understanding and using shortcodes in Flashquotes workflows"
 ---
 
-Shortcodes are dynamic placeholders that automatically insert relevant information into your workflow emails. They help personalize your messages and ensure accurate information is always included.
+Shortcodes are dynamic placeholders that automatically insert relevant information into your workflow emails and quote line items. They help personalize content and ensure accurate information is always included.
 
 Short codes are formatted as `{{entity.attribute}}` and must be surrounded by `{{}}` to be translated to a dynamic value.
 
@@ -12,6 +12,13 @@ Short codes are formatted as `{{entity.attribute}}` and must be surrounded by `{
 	it](/workflows/templates#testing-your-templates) with a quote to make sure
 	they work as expected
 </Tip>
+
+## Where Shortcodes Work
+
+Shortcodes resolve in:
+
+- **Workflow email templates** — Quote Sent, Quote Booked, First Event Start, Last Event End
+- **Quote line item descriptions** — Service and Add-on descriptions on a quote. Personalize each line with guest count, event date, customer name, and more using the same `{{entity.attribute}}` syntax. Shortcodes resolve when the quote is delivered.
 
 ## Available Shortcodes by Trigger
 


### PR DESCRIPTION
## Summary

Introduces the new **Scale** plan tier, backfills 9 changelog entries for the late-April through late-May releases, and adds the corresponding feature docs across the rest of the site.

### Plan tier
- New **Scale** tier on `/settings/plans` ($249/mo monthly, $199/mo annual) with dynamic pricing, full API access, and VIP priority support
- Adds `ScaleBadge` (orange) to `snippets/badge.mdx`
- Moves Full API access and VIP support out of Pro into Scale, and gates `api-reference/introduction` on the Scale plan with a "Scale access required" callout

### Changelog (newest first)
- May 21 — Auto-Calculate Travel Fee When Adding Services <PlusBadge />
- May 19 — Resource Availability and Calendar Improvements
- May 18 — Shortcodes in Line Item Descriptions
- May 12 — Pricing by Event Type <ScaleBadge />
- May 8 — Event Type on Quotes and Booked Events
- May 4 — Tiered Pricing for Volume Discounts
- May 1 — Surge Pricing and Days-Out Modifier <ScaleBadge />
- Apr 30 — Per-Staff-Hour Travel Billing <PlusBadge />
- Apr 30 — Per-Shift-Hour Labor Pricing

### Feature docs updated
- **services/pricing.mdx** — Hourly rate per staff (shift vs. service hours, both excluding travel), Tiered Per-Guest Pricing, new Per resource per hour mode (formula updated with a Resource Component), new Dynamic Pricing section (Surge, Days-Out, Event-Type modifiers), drop the duplicated Add-On Pricing section
- **services/travel-fees.mdx** — Per-Staff-Hour Travel Billing (in addition to per-mile, per-resource; not subject to the mileage minimum), Auto-Calculation in the Quote Editor
- **services/add-ons.mdx** — Tiered per-guest add-on pricing, Line Item Description supports shortcodes
- **services/core-services.mdx** — Line Item Description supports shortcodes
- **workflows/shortcodes/overview.mdx** — Shortcodes resolve in quote line item descriptions (at quote creation)
- **forms/lead-intake.mdx** — New Event Type connected question
- **calendar.mdx** — Service-time vs. shift-time toggle, multi-day events, Resource availability snapshot
- **resources.mdx** — Resource availability in the quote editor

### Authoring conventions
- New **CLAUDE.md** at the repo root documenting MDX character escaping (notably `\$` in price examples), plan tier badge usage, and changelog formatting

## Test plan
- [ ] `/settings/plans` shows four tiers, Scale row matches height, "Billed annually" subline renders correctly under each annual price
- [ ] `/services/pricing` — Dynamic Pricing section renders, all `$` examples display correctly, Per resource per hour examples render on separate lines
- [ ] `/services/travel-fees` — Per-Staff-Hour Travel Billing section renders; 2-hour round-trip example math reads cleanly
- [ ] `/api-reference/introduction` — orange Scale badge renders next to the title, Tip and Note reference the Scale plan
- [ ] `/changelog/overview` — May 21 → April 30 entries appear in correct order; ScaleBadge / PlusBadge render
- [ ] Spot-check all new internal links (`/services/travel-fees`, `/services/pricing#dynamic-pricing`, `/forms/lead-intake`, `/workflows/shortcodes/overview`, `/resources`, `/calendar#resource-availability`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new Scale plan tier with full API access, VIP support, and updated plan pricing/table
  * Per-staff-hour travel billing with automatic calculation in the quote editor
  * Tiered per-guest pricing and Event Type question for lead intake
  * Improved resource availability visibility in the quote editor/calendar

* **Documentation**
  * Expanded pricing docs with dynamic pricing (surge, days-out, event-type) and formula examples
  * Clarified shortcode behavior in quotes and workflows
  * Updated API access and plan-related copy; added Scale badge and changelog entries

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Flashquotes/docs/pull/12?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->