### PR TITLE
docs: Google Analytics attribution fix for Wix embeds

### DIFF
--- a/forms/wix-embeds.mdx
+++ b/forms/wix-embeds.mdx
@@ -68,6 +68,14 @@ If you prefer to keep the iframe embed on mobile, follow these optimization step
 - Ensure the embed code is wrapped in a div with at least 320px width and 650px height
 - Test the embed on actual mobile devices, not just Wix's mobile preview
 
+## Google Analytics and Ad Tracking
+
+Wix's sandboxed iframe also prevents your embedded form from reading the visitor's original traffic source, so Google Analytics records form events as `direct` instead of the campaign or Google Ads click that drove the visit. If you track conversions with Google Analytics, add the Flashquotes attribution script to your Wix header.
+
+<Card title="Fix Google Analytics attribution on Wix" icon="chart-line" href="/settings/integrations/google-analytics#using-google-analytics-on-wix">
+  Add one script to your Wix site's header so form events are attributed to the right source instead of `direct`.
+</Card>
+
 ## Next Steps
 
 After setting up your Wix embed:

--- a/settings/integrations/google-analytics.mdx
+++ b/settings/integrations/google-analytics.mdx
@@ -60,6 +60,43 @@ The `generate_lead` event also includes:
   </Step>
 </Steps>
 
+## Using Google Analytics on Wix
+
+Wix embeds your form inside a sandboxed iframe served from a separate Wix domain. Because of that sandbox, your form can't read the visitor's original traffic source or Google Ads click from the page it's embedded on — so GA4 records form events as **`direct`** instead of the campaign or ad that actually drove the visit.
+
+To fix attribution, add this script to your Wix site's header:
+
+```html
+<script src="https://app.flashquotes.com/wix-bridge.js"></script>
+```
+
+It passes the real traffic source from your page into the embedded form, so events are attributed correctly.
+
+<Note>
+Adding custom code requires a **paid Wix plan with a connected domain**.
+</Note>
+
+<Steps>
+  <Step title="Open Custom Code in Wix">
+    In your Wix dashboard, go to **Settings** > **Custom Code**, then click **+ Add Custom Code**.
+  </Step>
+  <Step title="Paste and place the script">
+    1. Paste the script above into the code box
+    2. Under **Add Code to Pages**, choose **All pages**
+    3. Under **Place Code in**, select **Head**
+    4. Click **Apply**
+  </Step>
+  <Step title="Verify attribution">
+    Visit your form's page with a test parameter like `?gclid=test123`, then submit a test lead. In GA4 **Reports > Realtime**, confirm the `generate_lead` event shows a source such as `google / cpc` instead of `direct`.
+
+    <Tip>
+    Use a fresh name, email, and phone number on each test — reusing the same details can merge into an existing lead and skip recording the source.
+    </Tip>
+  </Step>
+</Steps>
+
+Only Wix needs this script. WordPress, Squarespace, Webflow, and other builders place your form directly on the page, so attribution already works. See [Wix Embed Best Practices](/forms/wix-embeds) for more on Wix's constraints.
+
 ## Using UTM parameters
 
 Flashquotes automatically captures UTM parameters from your form URLs and includes them in all events. This lets you track which marketing campaigns drive the most leads.


### PR DESCRIPTION
> [!IMPORTANT]
> **Draft — do not merge until the fix is verified in production.** This documents the customer-facing setup for the Wix GA attribution fix in **Flashquotes/flashquotes#2018**. The `https://app.flashquotes.com/wix-bridge.js` script referenced here only exists once that PR deploys, and the attribution behavior needs a live GA4 DebugView check first. Merge once verified.

## What this adds

On Wix, our form is embedded in a cross-origin sandboxed iframe, so it can't see the page's Google Ads click (gclid) or GA4 session — GA4 logs every form event as `direct`. The fix is a one-line script the customer adds to their Wix site header, which passes the real traffic source into the embedded form.

- **`settings/integrations/google-analytics.mdx`** — new **Using Google Analytics on Wix** section: a short why, the script (in a copyable code block), the Wix Custom Code steps (Settings → Custom Code → Head, all pages; paid plan required), and a verify-with-`?gclid=test` step. Notes that only Wix needs it.
- **`forms/wix-embeds.mdx`** — a cross-link card from the existing "sandboxed iframes" discussion to that section.

## Notes

- The `<script>` snippet is in a fenced code block so MDX renders it as copyable code (doesn't execute).
- Edits existing pages only — no `docs.json` navigation changes.
- The unrelated untracked `services/staffing-rules.mdx` in the working tree is intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Wix embeds documentation with Google Analytics attribution details and implementation guidance
  * Added Wix-specific Google Analytics configuration instructions, including dashboard setup steps and verification procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->